### PR TITLE
exclude AvoidObjectMapperAsField

### DIFF
--- a/pmd/rulesets/backend-java-ruleset.xml
+++ b/pmd/rulesets/backend-java-ruleset.xml
@@ -17,6 +17,8 @@
         <!-- rules below fails du to missing exclusions on lombok annotations, deactivated until tweaked -->
         <exclude name="AvoidNonPrivateFieldsInSharedObjects"/>
         <exclude name="AvoidUnguardedMutableFieldsInSharedObjects"/>
+        <!-- rule AvoidModifyingObjectMapper is sufficient for us -->
+        <exclude name="AvoidObjectMapperAsField"/>
     </rule>
     <rule ref="https://raw.githubusercontent.com/jborgers/PMD-jPinpoint-rules/master/rulesets/java/jpinpoint-rules.xml/LimitStatementsInLambdas">
         <properties>


### PR DESCRIPTION
excluded rule [AvoidObjectMapperAsField](https://github.com/jborgers/PMD-jPinpoint-rules/blob/d79a452249486c59a0a72e8d42c4ffe7c0e64f35/docs/JavaCodePerformance.md\#iuojar02) 
as it doesn't work as describe in documentation 


```java
class ExceptionCase {
  private static final ObjectMapper staticObjectMapper = new ObjectMapper(); //accepted by AvoidObjectMapperAsField
  private final ObjectMapper mapperField = new ObjectMapper(); //bad by AvoidObjectMapperAsField

  public UserProfileDto getUserProfileDto(UserProfile userProfile) {
        return staticObjectMapper.convertValue(userProfile, UserProfileDto.class);
  }
}
```

but we get an error even though we don't set conf after initialisation so we should be good with only `AvoidModifyingObjectMapper`