### PR TITLE
deactivate UselessParentheses

### DIFF
--- a/pmd/rulesets/backend-java-ruleset.xml
+++ b/pmd/rulesets/backend-java-ruleset.xml
@@ -35,6 +35,8 @@
     </rule>
     <rule ref="io/github/dgroup/arch4u/pmd/arch4u-ruleset.xml">
         <exclude name="AvoidFieldNameMatchingMethodName"/>
+        <!-- UselessParentheses to reactivate in pmd 7.0.0 when it will have property ignoreClarifying-->
+        <exclude name="UselessParentheses"/>
         <exclude name="ClassNamingConventions"/>
         <exclude name="CloseResource"/>
         <exclude name="CommentDefaultAccessModifier"/>


### PR DESCRIPTION
deactivate rule UselessParentheses because we have many false positive as we use parentheses to clarify boolean expressions. 
We will reactivate it when pmd 7 will be released as it will be possible to set rule to allow parentheses when they are used for clarification. see : https://github.com/pmd/pmd/issues/1918