### PR TITLE
tweaks for pmd 7.0.0

### DIFF
--- a/pmd/rulesets/arch4u-ruleset-tweaked.xml
+++ b/pmd/rulesets/arch4u-ruleset-tweaked.xml
@@ -1,0 +1,277 @@
+<ruleset name="Custom Rules"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+    <description>All arch4u rules</description>
+
+    <!-- Rules related to JSON processing -->
+    <rule name="AvoidUsingObjectMapperAsALocalVariable"
+          since="0.1.0"
+          language="java"
+          externalInfoUrl="https://github.com/dgroup/arch4u-pmd/discussions/30"
+          message="ObjectMapper is better to have as a field rather than a local variable: https://github.com/dgroup/arch4u-pmd/discussions/30"
+          class="net.sourceforge.pmd.lang.rule.XPathRule">
+        <description>
+            ObjectMapper is better to have as a field rather than a local variable due to performance reasons.
+            It is allowed to be declared in fields, constructors, and initialization blocks.
+            Read more: https://github.com/dgroup/arch4u-pmd/discussions/30
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="annotations" type="List[String]"
+                      description="Full name of the method annotations in which it's allowed to use ObjectMapper as a field"
+                      value="javax.annotation.PostConstruct,org.springframework.context.annotation.Bean"/>
+            <property name="version" value="2.0"/>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+          //
+          (
+          Type/ReferenceType (: variable declaration :)
+          |
+          AllocationExpression (: constr invocation :)
+          )
+          /ClassOrInterfaceType
+          [pmd-java:typeIs('com.fasterxml.jackson.databind.ObjectMapper')]
+          [not(
+          ancestor::FieldDeclaration (: skip fields :)
+          or ancestor::Initializer   (: skip init blocks :)
+          or ancestor::ConstructorDeclaration (: skip constructor blocks :)
+          or ancestor::MethodDeclaration    (: skip methods with specified annotations :)
+            [preceding-sibling::Annotation
+              [some $annotation in $annotations satisfies pmd-java:typeIs($annotation)]
+            ]
+          )]
+          /.. (: violation points to the parent node :)
+          ]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+      import com.fasterxml.jackson.databind.ObjectMapper;
+      class Foo {
+          ObjectMapper objectMapper = new ObjectMapper(); //ok
+
+          {
+              objectMapper = new ObjectMapper();  //ok
+          }
+
+          Foo (ObjectMapper om) {                 //ok
+              objectMapper = new ObjectMapper();  //ok
+          }
+
+          void bar(ObjectMapper om) {                                  //violation
+              ObjectMapper mapper = om;                                //violation
+              mapper = new ObjectMapper();                             //violation
+              String str = new ObjectMapper().writeValueAsString(obj); //violation
+          }
+      }
+      ]]>
+        </example>
+    </rule>
+
+
+    <!-- Rules related to application monitoring -->
+
+    <rule name="UseConstantAsMetricName"
+          since="0.1.0"
+          language="java"
+          externalInfoUrl="https://github.com/dgroup/arch4u-pmd/discussions/75"
+          message="Use constant for metric name instead of hardcoded string literals: https://github.com/dgroup/arch4u-pmd/discussions/75"
+          class="net.sourceforge.pmd.lang.rule.XPathRule">
+        <description>
+            The monitoring metric name should be provided into annotation @Timed by constant, not a hardcoded string.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="metricAnnotations" type="List[String]"
+                      description="List of the metric annotations"
+                      value="io.micrometer.core.annotation.Timed"/>
+            <property name="version" value="2.0"/>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+          //Annotation[some $annotation in $metricAnnotations satisfies pmd-java:typeIsExactly($annotation)]
+          [
+          SingleMemberAnnotation/MemberValue/PrimaryExpression/PrimaryPrefix/Literal
+          or
+          NormalAnnotation/MemberValuePairs/MemberValuePair[@Image='value']/MemberValue/PrimaryExpression/PrimaryPrefix/Literal
+          ]
+          ]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+      import io.micrometer.core.annotation.Timed;
+
+      @RestController
+      public class MyController {
+
+         @Timed(Metrics.ORDER_PROCESSING_DURATION)   // ok
+         public X process(Order order) {
+            ...
+         }
+
+        @Timed("order_processing_duration")         // violation
+        public X process(Order order) {
+           ...
+         }
+      }
+      ]]>
+        </example>
+    </rule>
+
+
+    <!-- Rules related to error handling -->
+    <rule name="NoMandatoryConstructorInExceptionClass"
+          since="0.1.0"
+          language="java"
+          externalInfoUrl="https://github.com/dgroup/arch4u-pmd/discussions/31"
+          message="Exception class must have at least one constructor with signature `public Ctor(Throwable, String, Object...)` or `public Ctor(String, Object...)`: https://github.com/dgroup/arch4u-pmd/discussions/31"
+          class="net.sourceforge.pmd.lang.rule.XPathRule">
+        <description>
+            Exception class must have at least one constructor with signature
+            `public Ctor(Throwable, String, Object...)` or `public Ctor(String, Object...)`.
+            Read more: https://github.com/dgroup/arch4u-pmd/discussions/31
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="version" value="2.0"/>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+          //ClassOrInterfaceDeclaration
+          [pmd-java:typeIs('java.lang.Exception')] (: extends Exception class :)
+          [not(
+          ./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration[@Public=true()]
+          /FormalParameters[
+              (: Ctor(Throwable, String, Object...) :)
+              (./FormalParameter[1]/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIsExactly('java.lang.Throwable')]
+              and
+              ./FormalParameter[2]/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('java.lang.String')]
+              and
+              ./FormalParameter[3][@Varargs=true()]/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIsExactly('java.lang.Object')])
+              or
+              (: Ctor(String, Object...) :)
+              (./FormalParameter[1]/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('java.lang.String')]
+              and
+              ./FormalParameter[2][@Varargs=true()]/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIsExactly('java.lang.Object')])]
+          )]
+          ]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+          class MyException extends Exception {
+              public MyException(String pattern, Object... args) {}
+
+              public MyException(Throwable cause, String pattern, Object... args) {}
+          }
+          ]]>
+        </example>
+    </rule>
+
+    <!-- Third-party rules -->
+    <rule ref="category/java/bestpractices.xml">
+        <exclude
+                name="GuardLogStatement"/> <!-- @todo #/DEV GuardLogStatement: deep investigation is needed regarding purpose and goal of this this rule. Potentially improvement is needed. -->
+        <exclude name="UnusedPrivateMethod"/>
+    </rule>
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod">
+        <properties>
+            <property name="violationSuppressXPath"
+                      value="//ClassOrInterfaceDeclaration//Annotation/ClassOrInterfaceType[@SimpleName='PostConstruct']"/>
+        </properties>
+    </rule>
+    <rule ref="category/java/bestpractices.xml/JUnitAssertionsShouldIncludeMessage">
+        <properties>
+            <property name="violationSuppressXPath" value=".[ends-with(@Image,'assertEquals')]"/>
+        </properties>
+    </rule>
+    <rule ref="category/java/codestyle.xml">
+        <exclude name="AtLeastOneConstructor"/>
+        <exclude name="ShortClassName"/>
+        <exclude
+                name="OnlyOneReturn"/> <!-- @todo #/DEV OnlyOneReturn: deep investigation is needed regarding purpose and goal of this this rule. Potentially improvement is needed. -->
+        <exclude name="LongVariable"/>
+    </rule>
+    <rule ref="category/java/codestyle.xml/ShortClassName">
+        <properties>
+            <property name="minimum" value="3"/>
+        </properties>
+    </rule>
+    <rule ref="category/java/codestyle.xml/LongVariable">
+        <properties>
+            <property name="minimum" value="25"/>
+        </properties>
+    </rule>
+    <rule ref="category/java/design.xml">
+        <exclude
+                name="LawOfDemeter"/>  <!-- @todo #/DEV LawOfDemeter: deep investigation is needed regarding purpose and goal of this this rule. Potentially improvement is needed. -->
+        <exclude
+                name="UseObjectForClearerAPI"/> <!-- @todo #/DEV UseObjectForClearerAPI: deep investigation is needed regarding purpose and goal of this this rule. Potentially improvement is needed. -->
+        <exclude
+                name="AvoidCatchingGenericException"/> <!-- @todo #/DEV AvoidCatchingGenericException: deep investigation is needed regarding purpose and goal of this this rule. Potentially improvement is needed. -->
+        <exclude
+                name="SignatureDeclareThrowsException"/> <!-- @todo #/DEV SignatureDeclareThrowsException: deep investigation is needed regarding purpose and goal of this this rule. Potentially improvement is needed. -->
+        <exclude
+                name="ExcessiveImports"/> <!-- @todo #/DEV ExcessiveImports: deep investigation is needed regarding purpose and goal of this this rule. Potentially improvement is needed. -->
+        <exclude
+                name="LoosePackageCoupling"/> <!-- @todo #/DEV LoosePackageCoupling: deep investigation is needed regarding purpose and goal of this this rule. Potentially improvement is needed. -->
+        <exclude name="UseUtilityClass"/>
+        <exclude name="ImmutableField"/>
+    </rule>
+    <rule ref="category/java/design.xml/CouplingBetweenObjects">
+        <properties>
+            <property name="threshold" value="40"/>
+        </properties>
+    </rule>
+    <rule ref="category/java/design.xml/TooManyMethods">
+        <properties>
+            <property name="maxmethods" value="20"/>
+        </properties>
+    </rule>
+    <rule ref="category/java/design.xml/TooManyFields">
+        <properties>
+            <property name="maxfields" value="25"/>
+        </properties>
+    </rule>
+    <rule ref="category/java/design.xml/UseUtilityClass">
+        <properties>
+            <property name="violationSuppressXPath"
+                      value="//ClassOrInterfaceDeclaration//Annotation/ClassOrInterfaceType[@SimpleName='SpringBootApplication']"/>
+        </properties>
+    </rule>
+    <rule ref="category/java/design.xml/ImmutableField">
+        <properties>
+            <property name="violationSuppressXPath"
+                      value="//ClassOrInterfaceDeclaration//Annotation/ClassOrInterfaceType[@SimpleName='Entity' or @SimpleName='MappedSuperclass' ]"/>
+        </properties>
+    </rule>
+    <rule ref="category/java/documentation.xml">
+        <exclude name="CommentSize"/>
+        <exclude name="CommentRequired"/>
+    </rule>
+    <rule ref="category/java/documentation.xml/CommentRequired">
+        <properties>
+            <property name="fieldCommentRequirement" value="Ignored"/>
+            <property name="publicMethodCommentRequirement" value="Ignored"/>
+            <property name="protectedMethodCommentRequirement" value="Ignored"/>
+        </properties>
+    </rule>
+    <rule ref="category/java/multithreading.xml">
+        <exclude
+                name="UseConcurrentHashMap"/> <!-- @todo #/DEV UseConcurrentHashMap: deep investigation is needed regarding purpose and goal of this this rule. Potentially improvement is needed. -->
+    </rule>
+    <rule ref="category/java/performance.xml"/>
+    <rule ref="category/java/security.xml"/>
+    <rule ref="category/java/errorprone.xml">
+        <exclude
+                name="AvoidDuplicateLiterals"/> <!-- @todo #/DEV AvoidDuplicateLiterals: deep investigation is needed regarding purpose and goal of this this rule. Potentially improvement is needed. -->
+        <exclude
+                name="MissingSerialVersionUID"/> <!-- @todo #/DEV MissingSerialVersionUID: deep investigation is needed regarding purpose and goal of this this rule. Potentially improvement is needed. -->
+    </rule>
+</ruleset>

--- a/pmd/rulesets/backend-java-ruleset.xml
+++ b/pmd/rulesets/backend-java-ruleset.xml
@@ -36,7 +36,7 @@
                       value="//ClassOrInterfaceDeclaration['^[A-Z][a-zA-Z0-9]*(Test|IT)(s|Case)?$']"/>
         </properties>
     </rule>
-    <rule ref="io/github/dgroup/arch4u/pmd/arch4u-ruleset.xml">
+    <rule ref="https://raw.githubusercontent.com/libon/backend-code-rulesets/tweaks-for-pmd-7.0.0/pmd/rulesets/arch4u-ruleset-tweaked.xml">
         <!-- Too many false positive, as rule doesn't take object creation with interator derived objects into consideration-->
         <exclude name="AvoidInstantiatingObjectsInLoops"/>
         <exclude name="AvoidFieldNameMatchingMethodName"/>
@@ -46,12 +46,15 @@
         <exclude name="CloseResource"/>
         <exclude name="CommentDefaultAccessModifier"/>
         <exclude name="CommentRequired"/>
+        <exclude name="ConstructorCallsOverridableMethod"/>
         <exclude name="DataClass"/>
+        <exclude name="DoNotUseThreads"/>
         <exclude name="ExcessiveParameterList"/>
         <exclude name="GenericsNaming"/>
         <exclude name="JUnitAssertionsShouldIncludeMessage"/>
         <exclude name="JUnitTestContainsTooManyAsserts"/>
         <exclude name="LocalVariableCouldBeFinal"/>
+        <exclude name="LooseCoupling"/>
         <exclude name="LongVariable"/>
         <exclude name="MethodArgumentCouldBeFinal"/>
         <exclude name="MethodNamingConventions"/>
@@ -66,6 +69,7 @@
         <exclude name="UseLocaleWithCaseConversions"/>
         <exclude name="UseUnderscoresInNumericLiterals"/>
     </rule>
+
 
     <rule ref="category/java/codestyle.xml/ClassNamingConventions">
         <!--tweak to include test classes that ends with IT-->
@@ -127,7 +131,7 @@
         <!-- exclude constructors from rule -->
         <properties>
             <property name="violationSuppressXPath"
-                      value="//ClassOrInterfaceDeclaration[ClassOrInterfaceBody[not(ConstructorDeclaration)]]"/>
+                      value="//ConstructorDeclaration"/>
         </properties>
     </rule>
     <rule ref="category/java/documentation.xml/UncommentedEmptyConstructor">
@@ -153,7 +157,13 @@
                       value="//ClassOrInterfaceDeclaration['^[A-Z][a-zA-Z0-9_]*(Test|IT)(s|Case)?$']"/>
         </properties>
     </rule>
-
+    <rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod">
+        <properties>
+            <!--Ignore Rule when suppress warning is set-->
+            <property name="violationSuppressXPath"
+                      value="//ConstructorDeclaration//Annotation[@SimpleName ='SuppressWarnings']//MemberValuePair/StringLiteral[@ConstValue = 'this-escape']"/>
+        </properties>
+    </rule>
 
     <rule name="TooManyMethods"
           language="java"
@@ -169,7 +179,7 @@
         <priority>3</priority>
         <properties>
             <property name="maxmethods" type="Integer" description="The method count reporting threshold" min="1"
-                      max="1000" value="10"/>
+                      max="1000" value="20"/>
             <property name="xpath">
                 <value>
                     <![CDATA[
@@ -177,15 +187,24 @@
      [
       count(MethodDeclaration[
          not (
-                (starts-with(@Name,'get') or starts-with(@Name,'set') or starts-with(@Name,'is') or starts-with(@Name,'should') or ends-with(@Name,'Test'))
-                and
-                count(Block/*) <= 1
+                starts-with(@Name,'get')
+                or starts-with(@Name,'set')
+                or starts-with(@Name,'is')
+                or starts-with(@Name,'should')
+                or ends-with(@Name,'Test')
             )
       ]) > $maxmethods
    ]
 ]]>
                 </value>
             </property>
+        </properties>
+    </rule>
+    <rule ref="category/java/multithreading.xml/DoNotUseThreads">
+        <properties>
+            <!--Ignore AvoidHardcodedConnectionConfig on classes where the class name ends with IT or Test-->
+            <property name="violationSuppressXPath"
+                      value="//ClassOrInterfaceDeclaration['^[A-Z][a-zA-Z0-9]*(Test|IT)(s|Case)?$']"/>
         </properties>
     </rule>
 </ruleset>


### PR DESCRIPTION
fix https://github.com/libon/backend-system-backlog/issues/30


see https://github.com/libon/parent/pull/574
> Thanks to https://github.com/apache/maven-pmd-plugin/pull/141#issuecomment-1886820989 we don't need to use snapshot version of maven-pmd-plugin but only pmd release candidate 7.0.0-rc4

> The compatibility module only work on built in rules so I have removed arch4u rules but I have kept the rules that he had tweaked to reduce false positive occurrences when using framework like Spring. see [libon/backend-code-rulesets@tweaks-for-pmd-7.0.0/pmd/rulesets/arch4u-ruleset-tweaked.xml](https://github.com/libon/backend-code-rulesets/blob/tweaks-for-pmd-7.0.0/pmd/rulesets/arch4u-ruleset-tweaked.xml?rgh-link-date=2024-01-11T16%3A00%3A00Z)

> We loose https://github.com/dgroup/arch4u-pmd/discussions/43, https://github.com/dgroup/arch4u-pmd/discussions/73, https://github.com/dgroup/arch4u-pmd/discussions/74, https://github.com/dgroup/arch4u-pmd/discussions/75 https://github.com/dgroup/arch4u-pmd/discussions/31, https://github.com/dgroup/arch4u-pmd/discussions/30, https://github.com/dgroup/arch4u-pmd/discussions/86, https://github.com/dgroup/arch4u-pmd/discussions/88 from archu4pmd as this rules were custom rules made in java with the pmd api.