### PR TITLE
ignore ExcessiveParameterList when it's an overriding method

### DIFF
--- a/pmd/rulesets/backend-java-ruleset.xml
+++ b/pmd/rulesets/backend-java-ruleset.xml
@@ -131,7 +131,7 @@
         <!-- exclude constructors from rule -->
         <properties>
             <property name="violationSuppressXPath"
-                      value="//ConstructorDeclaration"/>
+                      value="//ConstructorDeclaration | //MethodDeclaration//Annotation[@SimpleName = 'Override']"/>
         </properties>
     </rule>
     <rule ref="category/java/documentation.xml/UncommentedEmptyConstructor">


### PR DESCRIPTION
When we are overriding a method, its not our fault if we have too many parameters