### PR TITLE
exclude UtilityClass from DataClass

### DIFF
--- a/pmd/rulesets/backend-java-ruleset.xml
+++ b/pmd/rulesets/backend-java-ruleset.xml
@@ -134,10 +134,11 @@
     </rule>
 
     <rule ref="category/java/design.xml/DataClass">
-        <!-- remove entities from rule -->
+        <!-- remove entities and utility class from rule -->
         <properties>
             <property name="violationSuppressXPath"
-                      value="//TypeDeclaration/Annotation/MarkerAnnotation/Name[@Image='Entity']"/>
+                      value="//TypeDeclaration/Annotation/MarkerAnnotation/Name[@Image='Entity']
+                             | //TypeDeclaration/Annotation/MarkerAnnotation/Name[@Image='UtilityClass']"/>
         </properties>
     </rule>
     <rule ref="category/java/design.xml/CyclomaticComplexity">


### PR DESCRIPTION
When we annotate data class with @UtilityClass it means that we thought about it and it is relevant to have this data class