### PR TITLE
exclude SwitchDensity rule

### DIFF
--- a/pmd/rulesets/backend-java-ruleset.xml
+++ b/pmd/rulesets/backend-java-ruleset.xml
@@ -63,6 +63,7 @@
         <exclude name="NullAssignment"/>
         <exclude name="ShortMethodName"/>
         <exclude name="ShortVariable"/>
+        <exclude name="SwitchDensityRule"/>
         <!-- to enable back when https://github.com/pmd/pmd/issues/4813 is fixed-->
         <exclude name="SwitchStmtsShouldHaveDefault"/>
         <exclude name="TooFewBranchesForASwitchStatement"/>


### PR DESCRIPTION
Since we use pattern matching this rule is no longer relevant