### PR TITLE
exclude SwitchDensity rule from jpinpoint

### DIFF
--- a/pmd/rulesets/backend-java-ruleset.xml
+++ b/pmd/rulesets/backend-java-ruleset.xml
@@ -22,6 +22,7 @@
         <!-- rule NonComparableMapKeys deactivated as we can't easily restrict it to our packages.
         To reactivate in pmd 7.0.0 as each node will have a getRoot method which will return package name -->
         <exclude name="NonComparableMapKeys"/>
+        <exclude name="SwitchDensityRule"/>
     </rule>
     <rule ref="https://raw.githubusercontent.com/jborgers/PMD-jPinpoint-rules/44375f0e771757ad0798d2e6947d3aa37ef69d3d/rulesets/java/jpinpoint-rules.xml/LimitStatementsInLambdas">
         <properties>
@@ -63,7 +64,6 @@
         <exclude name="NullAssignment"/>
         <exclude name="ShortMethodName"/>
         <exclude name="ShortVariable"/>
-        <exclude name="SwitchDensityRule"/>
         <!-- to enable back when https://github.com/pmd/pmd/issues/4813 is fixed-->
         <exclude name="SwitchStmtsShouldHaveDefault"/>
         <exclude name="TooFewBranchesForASwitchStatement"/>


### PR DESCRIPTION
rule was not from arch4u-ruleset-tweaked

```
[WARNING] Warning at /home/jenkins/agent/workspace/Libon_backend-dps_PR-79@tmp/codeAnalysis.tmp16542854950258801439/domain-objects/target/pmd/rulesets/001-backend-java-ruleset.xml:66:9
10:22:47   64|         <exclude name="ShortMethodName"/>
10:22:47   65|         <exclude name="ShortVariable"/>
10:22:47   66|         <exclude name="SwitchDensityRule"/>
10:22:47               ^^^^^^^^ Exclude pattern 'SwitchDensityRule' did not match any rule in ruleset 'https://raw.githubusercontent.com/libon/backend-code-rulesets/tweaks-for-pmd-7.0.0/pmd/rulesets/arch4u-ruleset-tweaked.xml'
10:22:47  
10:22:47   67|         <!-- to enable back when https://github.com/pmd/pmd/issues/4813 is fixed-->
10:22:47   68|         <exclude name="SwitchStmtsShouldHaveDefault"/>
```