### PR TITLE
remove SwitchDensityRule exclusion

### DIFF
--- a/pmd/rulesets/backend-java-ruleset.xml
+++ b/pmd/rulesets/backend-java-ruleset.xml
@@ -22,7 +22,6 @@
         <!-- rule NonComparableMapKeys deactivated as we can't easily restrict it to our packages.
         To reactivate in pmd 7.0.0 as each node will have a getRoot method which will return package name -->
         <exclude name="NonComparableMapKeys"/>
-        <exclude name="SwitchDensityRule"/>
     </rule>
     <rule ref="https://raw.githubusercontent.com/jborgers/PMD-jPinpoint-rules/44375f0e771757ad0798d2e6947d3aa37ef69d3d/rulesets/java/jpinpoint-rules.xml/LimitStatementsInLambdas">
         <properties>


### PR DESCRIPTION
rule is also not found in SwitchDensityRule

```
[WARNING] Warning at /home/jenkins/agent/workspace/Libon_backend-dps_PR-79@tmp/codeAnalysis.tmp4732337927714008743/providers/sochitel/target/pmd/rulesets/001-backend-java-ruleset.xml:25:9
10:48:22   23|         To reactivate in pmd 7.0.0 as each node will have a getRoot method which will return package name -->
10:48:22   24|         <exclude name="NonComparableMapKeys"/>
10:48:22   25|         <exclude name="SwitchDensityRule"/>
10:48:22               ^^^^^^^^ Exclude pattern 'SwitchDensityRule' did not match any rule in ruleset 'https://raw.githubusercontent.com/jborgers/PMD-jPinpoint-rules/44375f0e771757ad0798d2e6947d3aa37ef69d3d/rulesets/java/jpinpoint-rules.xml'
10:48:22  
10:48:22   26|     </rule>
10:48:22   27|     <rule ref="https://raw.githubusercontent.com/jborgers/PMD-jPinpoint-rules/44375f0e771757ad0798d2e6947d3aa37ef69d3d/rulesets/java/jpinpoint-rules.xml/LimitStatementsInLambdas">
```