### PR TITLE
Exclude SwitchDensity rule

### DIFF
--- a/pmd/rulesets/backend-java-ruleset.xml
+++ b/pmd/rulesets/backend-java-ruleset.xml
@@ -63,6 +63,8 @@
         <exclude name="NullAssignment"/>
         <exclude name="ShortMethodName"/>
         <exclude name="ShortVariable"/>
+        <!-- to enable back when https://github.com/pmd/pmd/issues/5030 is fixed -->
+        <exclude name="SwitchDensityRule"/>
         <!-- to enable back when https://github.com/pmd/pmd/issues/4813 is fixed-->
         <exclude name="SwitchStmtsShouldHaveDefault"/>
         <exclude name="TooFewBranchesForASwitchStatement"/>


### PR DESCRIPTION
It gives false-positives on switch expressions
PMD issue : https://github.com/pmd/pmd/issues/5030
Example : https://github.com/libon/server-archiver/pull/5017/files#diff-d49f5d2827ed9ba728cd85a5a358f8e3432fdd939372fb3e51e8648b1b74998eR143-R148