### PR TITLE
suppress ExcessivePublicCount on Enums

### DIFF
--- a/pmd/rulesets/backend-java-ruleset.xml
+++ b/pmd/rulesets/backend-java-ruleset.xml
@@ -18,6 +18,7 @@
         <exclude name="DoNotUseThreads"/>
         <exclude name="EmptyCatchBlock"/>
         <exclude name="ExcessiveParameterList"/>
+        <exclude name="ExcessivePublicCount"/>
         <exclude name="GenericsNaming"/>
         <exclude name="LocalVariableCouldBeFinal"/>
         <exclude name="LongVariable"/>
@@ -124,6 +125,13 @@
                       value="//ConstructorDeclaration | //MethodDeclaration/ModifierList/Annotation/ClassType[@SimpleName = 'Override']"/>
         </properties>
     </rule>
+    <rule ref="category/java/design.xml/ExcessivePublicCount">
+        <properties>
+            <property name="violationSuppressXPath"
+                      value="./*[pmd-java:nodeIs('EnumDeclaration')]"/>
+        </properties>
+    </rule>
+
     <rule ref="category/java/documentation.xml/UncommentedEmptyConstructor">
         <properties>
             <!-- ignore empty constructor on model classes as it is needed for Jackson


### PR DESCRIPTION
When an enum has a lot of entries we get this warning, recommending to split into multiple classes but this would change the behavior when its used