### PR TITLE
suppress MoreThanOneLogger on custom string loggers

### DIFF
--- a/pmd/rulesets/backend-java-ruleset.xml
+++ b/pmd/rulesets/backend-java-ruleset.xml
@@ -25,6 +25,7 @@
         <exclude name="LooseCoupling"/>
         <exclude name="MethodArgumentCouldBeFinal"/>
         <exclude name="MethodNamingConventions"/>
+        <exclude name="MoreThanOneLogger"/>
         <exclude name="NonSerializableClass"/>
         <exclude name="NullAssignment"/>
         <exclude name="PrematureDeclaration"/>
@@ -177,7 +178,13 @@
             <property name="allowExceptionNameRegex" value="^(ignored|expected)$"/>
         </properties>
     </rule>
-
+    <rule ref="category/java/errorprone.xml/MoreThanOneLogger">
+        <properties>
+            <!--Ignore rule when other loggers are specific loggers (i.e. not based on a class name) -->
+            <property name="violationSuppressXPath"
+                      value="//ClassDeclaration/ClassBody[count(.//MethodCall[@MethodName = 'getLogger' and ./ArgumentList/ClassLiteral ]) = 0]"/>
+        </properties>
+    </rule>
     <rule ref="category/java/errorprone.xml/TestClassWithoutTestCases">
         <properties>
             <property name="testClassPattern" value="^[A-Z][a-zA-Z0-9_]+(Test|IT)(s|Case)?$"/>


### PR DESCRIPTION
we only want to have warn `MoreThanOneLogger` when multiple class based logger are defined in the class and not when other logger are specific loggers (i.e. based on custom strings)

```java
     // Valid
    private static final Logger LOGGER = LoggerFactory.getLogger(CallAuthorizationService.class);
    private static final Logger NUMBER_PATTERN_LOGGER = LoggerFactory.getLogger("number-pattern-logger");
    private static final Logger DIFF_LOGGER = LoggerFactory.getLogger("diff-logger");
```

```java
     // Not valid
    private static final Logger LOGGER = LoggerFactory.getLogger(CallAuthorizationService.class);
    private static final Logger NUMBER_PATTERN_LOGGER = LoggerFactory.getLogger(NumberMatcher.class);
    private static final Logger DIFF_LOGGER = LoggerFactory.getLogger("diff-logger");
```