### PR TITLE
ignore private methods for TooManyMethods

### DIFF
--- a/pmd/rulesets/backend-java-ruleset.xml
+++ b/pmd/rulesets/backend-java-ruleset.xml
@@ -212,6 +212,7 @@
  //ClassDeclaration/ClassBody
      [
       count(MethodDeclaration[
+          not(@EffectiveVisibility = 'private') and
          not (
                 starts-with(@Name,'get')
                 or starts-with(@Name,'set')


### PR DESCRIPTION
When we have private methods in our classes it is most of the time to clarify an exposed method in the class so lets exclude them from count because it would be less readable/maintainable to have them else where