### PR TITLE
ignore more magic numbers for AvoidLiteralsInIfCondition

### DIFF
--- a/pmd/rulesets/backend-java-ruleset.xml
+++ b/pmd/rulesets/backend-java-ruleset.xml
@@ -8,6 +8,7 @@
         <exclude name="AvoidFieldNameMatchingMethodName"/>
         <!-- Too many false positive, as rule doesn't take object creation with interator derived objects into consideration-->
         <exclude name="AvoidInstantiatingObjectsInLoops"/>
+        <exclude name="AvoidLiteralsInIfCondition"/>
         <exclude name="ClassNamingConventions"/>
         <exclude name="CloseResource"/>
         <exclude name="CommentDefaultAccessModifier"/>
@@ -163,6 +164,12 @@
                            ]"/>
         </properties>
     </rule>
+    <rule ref="category/java/errorprone.xml/AvoidLiteralsInIfCondition">
+        <properties>
+            <property name="ignoreMagicNumbers" value="-1,0,1,2,3"/>
+        </properties>
+    </rule>
+
     <rule ref="category/java/errorprone.xml/CloseResource">
         <properties>
             <!--Ignore CloseResource on Test Classes-->


### PR DESCRIPTION
add more magic numbers to be ignored : https://pmd.github.io/pmd/pmd_rules_java_errorprone.html#avoidliteralsinifcondition

when using string.split we tend to check that the resulting array have the right size so we often use 1,2 or 3 in if conditions